### PR TITLE
Fix issues #6, #7, #8 in plugin wiring

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Inter-region latency statistics plugin for [az-scout](https://github.com/lrivall
 - **API endpoints** — `POST /plugins/latency-stats/matrix` for pairwise latency matrices, `GET /plugins/latency-stats/pairs` to list all known pairs
 - **MCP tool** — `region_latency(source_region, target_region)` returns indicative RTT between two Azure regions
 - **UI tab** — interactive D3.js force-directed graph where regions are nodes and edges show latency in ms
-- **URL hash routing** — `#latency` selects the plugin tab
+- **URL hash routing** — `#latency-stats` selects the plugin tab
 
 ## Setup
 
@@ -57,7 +57,7 @@ az-scout-plugin-latency-stats/
 
 ## How it works
 
-1. The plugin JS loads the HTML fragment into `#plugin-tab-latency`.
+1. The plugin JS loads the HTML fragment into `#plugin-tab-latency-stats`.
 2. Regions are populated from the main app's `regions` global.
 3. The user selects 2+ regions and clicks **Show Latency Graph**.
 4. The plugin calls `POST /plugins/latency-stats/matrix` with the selected regions.

--- a/src/az_scout_latency_stats/__init__.py
+++ b/src/az_scout_latency_stats/__init__.py
@@ -30,12 +30,16 @@ class LatencyStatsPlugin:
     version = __version__
 
     def __init__(self) -> None:
-        from az_scout_latency_stats.cloud63 import prewarm_cloud63
-
-        prewarm_cloud63()
+        self._prewarmed = False
 
     def get_router(self) -> APIRouter | None:
         """Return API routes for latency data."""
+        if not self._prewarmed:
+            from az_scout_latency_stats.cloud63 import prewarm_cloud63
+
+            prewarm_cloud63()
+            self._prewarmed = True
+
         from az_scout_latency_stats.routes import router
 
         return router
@@ -54,13 +58,22 @@ class LatencyStatsPlugin:
         """Return UI tab definitions."""
         return [
             TabDefinition(
-                id="latency",
+                id="latency-stats",
                 label="Latency",
                 icon="bi bi-globe-americas",
                 js_entry="js/latency-tab.js",
                 css_entry="css/latency.css",
             )
         ]
+
+    def get_system_prompt_addendum(self) -> str | None:
+        """Return extra guidance for the default discussion chat mode."""
+        return (
+            "For inter-region latency questions, use the region_latency tool. "
+            "It supports two data sources: 'azuredocs' (Microsoft published stats) "
+            "and 'cloud63' (crowd-sourced measurements from the Azure Latency Test project). "
+            "Default to 'azuredocs' unless the user asks for cloud63 data."
+        )
 
     def get_chat_modes(self) -> list[ChatMode] | None:
         """Return chat mode definitions, or None to skip."""

--- a/src/az_scout_latency_stats/static/js/latency-tab.js
+++ b/src/az_scout_latency_stats/static/js/latency-tab.js
@@ -3,7 +3,7 @@
 // coloured by pairwise RTT (ms).
 (function () {
     const PLUGIN_NAME = "latency-stats";
-    const TAB_ID = "latency";
+    const TAB_ID = "latency-stats";
     const container = document.getElementById("plugin-tab-" + TAB_ID);
     if (!container) return;
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,0 +1,43 @@
+"""Tests for plugin wiring and metadata."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from az_scout_latency_stats import LatencyStatsPlugin
+
+
+class TestLatencyStatsPlugin:
+    """Unit tests for LatencyStatsPlugin."""
+
+    def test_get_router_prewarms_once_and_is_lazy(self) -> None:
+        with patch("az_scout_latency_stats.cloud63.prewarm_cloud63") as prewarm_mock:
+            plugin = LatencyStatsPlugin()
+            prewarm_mock.assert_not_called()
+
+            router1 = plugin.get_router()
+            router2 = plugin.get_router()
+
+        assert router1 is not None
+        assert router2 is not None
+        assert router1 is router2
+        prewarm_mock.assert_called_once()
+
+    def test_tab_id_matches_plugin_slug(self) -> None:
+        plugin = LatencyStatsPlugin()
+
+        tabs = plugin.get_tabs()
+
+        assert tabs is not None
+        assert len(tabs) == 1
+        assert tabs[0].id == "latency-stats"
+
+    def test_system_prompt_addendum_mentions_tool_and_sources(self) -> None:
+        plugin = LatencyStatsPlugin()
+
+        addendum = plugin.get_system_prompt_addendum()
+
+        assert addendum is not None
+        assert "region_latency" in addendum
+        assert "azuredocs" in addendum
+        assert "cloud63" in addendum


### PR DESCRIPTION
## Summary
- add `get_system_prompt_addendum()` so discussion mode routes inter-region latency questions to `region_latency`
- move Cloud63 prewarm from plugin constructor to one-time lazy call in `get_router()`
- align tab id with plugin slug: `latency-stats` and update JS container lookup
- update README hash/container references
- add plugin regression tests for lazy prewarm, tab id alignment, and system prompt addendum

## Validation
- uv run ruff check src/ tests/
- uv run mypy src/
- uv run pytest

Closes #6
Closes #7
Closes #8
